### PR TITLE
run star listeners last

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ they run asynchronously.
 Create a new `nanobus` instance
 
 ### `bus.emit(eventName, [data])`
-Emit an event. Arbitrary data can optionally be passed as an argument.
+Emit an event. Arbitrary data can optionally be passed as an argument. `'*'`
+listeners run after named listeners.
 
 ### `bus.on(eventName, listener([data]))`
 Listen to an event.

--- a/index.js
+++ b/index.js
@@ -11,12 +11,12 @@ function Nanobus () {
 Nanobus.prototype.emit = function (eventName, data) {
   assert.equal(typeof eventName, 'string', 'nanobus.emit: eventName should be type string')
 
+  var listeners = this._listeners[eventName]
+  if (listeners && listeners.length) this._emit(listeners, data)
+
   if (this._starListeners.length) {
     this._emit(this._starListeners, eventName, data)
   }
-
-  var listeners = this._listeners[eventName]
-  if (listeners && listeners.length) this._emit(listeners, data)
 
   return this
 }


### PR DESCRIPTION
Needed for https://github.com/yoshuawuyts/choo/issues/446 - don't think it'll break anything as (somewhat hypocritical) this behavior was undocumented and shouldn't be relied on - but I think it makes more sense to have globs run last as commonly they'd be used for logging & debugging which I feel makes sense to run _after_ the other steps have completed. Or maybe I'm wrong - you tell me