### PR TITLE
Fix error thrown when both once() and on() are used with the same eventName

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,12 +11,13 @@ function Nanobus () {
 Nanobus.prototype.emit = function (eventName, data) {
   assert.equal(typeof eventName, 'string', 'nanobus.emit: eventName should be type string')
 
-  var listeners = this.listeners(eventName)
-  if (listeners && listeners.length) this._emit(listeners, data)
+  var listeners = this._listeners[eventName]
+  if (listeners && listeners.length > 0) {
+    this._emit(this.listeners(eventName), data)
+  }
 
-  if (this._starListeners.length) {
-    var starListeners = this.listeners('*')
-    this._emit(starListeners, eventName, data)
+  if (this._starListeners.length > 0) {
+    this._emit(this.listeners('*'), eventName, data)
   }
 
   return this
@@ -83,7 +84,7 @@ Nanobus.prototype.removeAllListeners = function (eventName) {
 }
 
 Nanobus.prototype.listeners = function (eventName) {
-  var listeners = (eventName === '*') ? this._starListeners : this._listeners[eventName]
+  var listeners = (eventName !== '*') ? this._listeners[eventName] : this._starListeners
   var ret = []
   if (listeners) {
     var ilength = listeners.length

--- a/index.js
+++ b/index.js
@@ -11,11 +11,12 @@ function Nanobus () {
 Nanobus.prototype.emit = function (eventName, data) {
   assert.equal(typeof eventName, 'string', 'nanobus.emit: eventName should be type string')
 
-  var listeners = this._listeners[eventName]
+  var listeners = this.listeners(eventName)
   if (listeners && listeners.length) this._emit(listeners, data)
 
   if (this._starListeners.length) {
-    this._emit(this._starListeners, eventName, data)
+    var starListeners = this.listeners('*')
+    this._emit(starListeners, eventName, data)
   }
 
   return this
@@ -82,7 +83,7 @@ Nanobus.prototype.removeAllListeners = function (eventName) {
 }
 
 Nanobus.prototype.listeners = function (eventName) {
-  var listeners = this._listeners[eventName]
+  var listeners = (eventName === '*') ? this._starListeners : this._listeners[eventName]
   var ret = []
   if (listeners) {
     var ilength = listeners.length

--- a/test.js
+++ b/test.js
@@ -42,6 +42,34 @@ tape('nanobus', function (t) {
     bus.emit('foo:bar')
   })
 
+  t.test('should properly emit messages when using both once() and on() ', function (t) {
+    t.plan(2)
+    var bus = nanobus()
+    var i = 0
+
+    bus.once('foo:bar', function onceIncrement () {
+      i++
+    })
+
+    bus.on('foo:bar', function onIncrement () {
+      i++
+    })
+
+    bus.once('*', function wildcardOnceIncrement () {
+      i++
+    })
+
+    bus.on('*', function wildcardOnIncrement () {
+      i++
+    })
+
+    bus.emit('foo:bar')
+    t.equal(i, 4, 'incremented by once() and on()')
+
+    bus.emit('foo:bar')
+    t.equal(i, 6, 'incremented by on() only')
+  })
+
   t.test('should trigger wildcard once', function (t) {
     t.plan(3)
     var bus = nanobus()


### PR DESCRIPTION
I took a stab at fixing #7  by passing a copy of the `_listeners` array to `_emit()` so the length won't change while the original `_listeners` array mutates as `once()` callbacks are triggered.

It seemed to make senses to use the existing `listeners()` method since it returns a copy.

The when I run the  benchmarks the are between 5ms and 50ms slower.

