### PR TITLE
Avoid array allocation on .emit()

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,11 +19,11 @@ Nanobus.prototype.emit = function (eventName, data) {
   this._timing.start(eventName)
   var listeners = this._listeners[eventName]
   if (listeners && listeners.length > 0) {
-    this._emit(this.listeners(eventName), data)
+    this._emit(this._listeners[eventName], data)
   }
 
   if (this._starListeners.length > 0) {
-    this._emit(this.listeners('*'), eventName, data)
+    this._emit(this._starListeners, eventName, data)
   }
   this._timing.end(eventName)
 
@@ -87,9 +87,14 @@ Nanobus.prototype.removeListener = function (eventName, listener) {
   assert.equal(typeof listener, 'function', 'nanobus.removeListener: listener should be type function')
 
   if (eventName === '*') {
-    if (remove(this._starListeners, listener)) return this
+    this._starListeners = this._starListeners.slice()
+    return remove(this._starListeners, listener)
   } else {
-    if (remove(this._listeners[eventName], listener)) return this
+    if (typeof this._listeners[eventName] !== 'undefined') {
+      this._listeners[eventName] = this._listeners[eventName].slice()
+    }
+
+    return remove(this._listeners[eventName], listener)
   }
 
   function remove (arr, listener) {
@@ -127,6 +132,7 @@ Nanobus.prototype.listeners = function (eventName) {
 }
 
 Nanobus.prototype._emit = function (arr, eventName, data) {
+  if (typeof arr === 'undefined') return
   if (!data) {
     data = eventName
     eventName = null

--- a/test.js
+++ b/test.js
@@ -234,4 +234,18 @@ tape('nanobus', function (t) {
       i++
     }
   })
+
+  t.test('should be able to remove listeners that have not been attached', function (t) {
+    var bus = nanobus()
+
+    t.doesNotThrow(function () {
+      bus.removeListener('yay', handler)
+    }, 'removes unattched "yay" event')
+    t.doesNotThrow(function () {
+      bus.removeListener('*', handler)
+    }, 'removes unattached "*" event')
+    t.end()
+
+    function handler () {}
+  })
 })


### PR DESCRIPTION
Hey! Finally have the chance to play with some of your new stuff on a project :D Here's a fix to squash a sneaky allocation for better perf 🔥

Removing this allocation results in a ~1.75x speedup for calls to `emit()`, in exchange for slightly slower calls to `removeListener()`. Note that now the event arrays are copied when removing a listener, to prevent unexpected behaviour when a listener is removed halfway through the emit loop.

I wasn't entirely sure what to do with the return value for `removeListener()`, so for now it returns `true` if it removed any events.

Hope all's well over in DE 😁

<img width="300" alt="screen shot 2017-05-21 at 1 58 57 am" src="https://cloud.githubusercontent.com/assets/569817/26277399/df379194-3dc9-11e7-9116-08e277d17c29.png"> <img width="300" alt="screen shot 2017-05-21 at 1 59 07 am" src="https://cloud.githubusercontent.com/assets/569817/26277400/df3c5e68-3dc9-11e7-9067-65a366ae68be.png">

